### PR TITLE
Condition isSmooth on fontSize

### DIFF
--- a/src/MSDFText/index.ts
+++ b/src/MSDFText/index.ts
@@ -9,8 +9,10 @@ export class MSDFText extends THREE.Mesh<MSDFTextGeometry, MSDFTextNodeMaterial>
   readonly element: HTMLElement | undefined
   
   constructor(metrics: DomTextMetrics, font: { atlas: THREE.Texture, data: BMFontJSON }) {
+    const isSmooth = metrics.fontCssStyles.fontSize < 32 ? 1 : 0;
+    
     const geometry = new MSDFTextGeometry({ metrics, font: font.data })
-    const material = new MSDFTextNodeMaterial(font.atlas, { color: metrics.fontCssStyles.color })
+    const material = new MSDFTextNodeMaterial(font.atlas, { color: metrics.fontCssStyles.color, isSmooth })
     
     super(geometry, material)
     


### PR DESCRIPTION
Enable the isSmooth flag on the material if the font size is less than 32px. This should make small text more legible.